### PR TITLE
[Feature] QR code quite zone

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ QR Code generation either with the included `QRCodeRect` node or use the encodin
   Turn this off when the QR Code changes or is resized often, as it impacts the performance quite heavily.
 - `module_px_size: int`  
   Use that many pixel for one module.
+- `quiet_zone_size: int`  
+  Use that many modules for the quiet zone. A value of 4 is recommended.
 
 **QRCode** - [`addons/qr_code/qr_code.gd`](./addons/qr_code/qr_code.gd)
 

--- a/README.md
+++ b/README.md
@@ -402,6 +402,12 @@ Shift JIS encoding utility.
 - `static func to_jis_8_buffer(text: String) -> PackedByteArray`
 - `static func get_string_from_jis_8(arr: PackedByteArray) -> String`
 
+### Changelog
+
+#### 0.2.0
+
+- Added quiet zone size property
+
 ---
 
 ## TextureButtonColored

--- a/addons/qr_code/plugin.cfg
+++ b/addons/qr_code/plugin.cfg
@@ -3,5 +3,5 @@
 name="QR Code"
 description="QR Code generator. - MIT License"
 author="Iceflower S"
-version="0.1.1"
+version="0.2.0"
 script="plugin.gd"

--- a/addons/qr_code/qr_code.gd
+++ b/addons/qr_code/qr_code.gd
@@ -895,27 +895,28 @@ func _init(error_correction_: ErrorCorrection = ErrorCorrection.LOW) -> void:
         _static_init()
 
 ## generate an QR code image
-func generate_image(module_px_size: int = 1, light_module_color: Color = Color.WHITE, dark_module_color: Color = Color.BLACK) -> Image:
+func generate_image(module_px_size: int = 1, light_module_color: Color = Color.WHITE, dark_module_color: Color = Color.BLACK, quiet_zone_size: int = 4) -> Image:
     module_px_size = max(1, module_px_size)
+    quiet_zone_size = max(0, quiet_zone_size)
 
     var qr_code: PackedByteArray = self.encode()
 
     var module_count: int = self.get_module_count()
-    var image: Image = Image.create(module_count * module_px_size, module_count * module_px_size, false, Image.FORMAT_RGB8)
+    var image_size: int = (module_count + 2 * quiet_zone_size) * module_px_size
+    var image: Image = Image.create(image_size, image_size, false, Image.FORMAT_RGB8)
+    image.fill(light_module_color)
 
     for y in range(module_count):
         for x in range(module_count):
-            var color: Color = Color.WHITE
+            var color: Color = Color.PINK
             match qr_code[x + y * module_count]:
                 0:
                     color = light_module_color
                 1:
                     color = dark_module_color
-                _:
-                    color = Color.PINK
             for offset_x in range(module_px_size):
                 for offset_y in range(module_px_size):
-                    image.set_pixel(x * module_px_size + offset_x, y * module_px_size + offset_y, color)
+                    image.set_pixel((x + quiet_zone_size) * module_px_size + offset_x, (y + quiet_zone_size) * module_px_size + offset_y, color)
 
     return image
 

--- a/addons/qr_code/qr_code_rect.gd
+++ b/addons/qr_code/qr_code_rect.gd
@@ -48,6 +48,9 @@ var auto_module_px_size: bool = true:
 ## Use that many pixel for one module.
 var module_px_size: int = 1:
     set = set_module_px_size
+## Use that many modules for the quite zone. A value of 4 is recommend.
+var quiet_zone_size: int = 4:
+    set = set_quiet_zone_size
 
 func set_mode(new_mode: QRCode.Mode) -> void:
     self._qr.mode = new_mode
@@ -163,6 +166,10 @@ func set_module_px_size(new_module_px_size: int) -> void:
     if !self.auto_module_px_size:
         self._update_qr()
 
+func set_quiet_zone_size(new_quiet_zone_size: int) -> void:
+    quiet_zone_size = max(0, new_quiet_zone_size)
+    self._update_qr()
+
 func _init() -> void:
     if self.texture != null:
         self._update_qr()
@@ -219,8 +226,6 @@ func _get_property_list() -> Array[Dictionary]:
         "hint": PROPERTY_HINT_RANGE,
         "hint_string": "1,1,or_greater"
     }
-    if self.auto_module_px_size:
-        module_px_size_prop["usage"] = (module_px_size_prop["usage"] | PROPERTY_USAGE_READ_ONLY) & ~PROPERTY_USAGE_STORAGE
 
     return [
         data_prop,
@@ -256,11 +261,17 @@ func _get_property_list() -> Array[Dictionary]:
             "type": TYPE_BOOL,
             "usage": PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE,
         },
-        module_px_size_prop
+        module_px_size_prop,
+        {
+            "name": "quiet_zone_size",
+            "type": TYPE_INT,
+            "usage": PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_STORAGE,
+            "hint_string": "0,1,or_greater",
+        },
     ]
 
 func _property_can_revert(property: StringName) -> bool:
-    return property in ["auto_version", "auto_mask_pattern", "light_module_color", "dark_module_color", "auto_module_px_size"]
+    return property in ["auto_version", "auto_mask_pattern", "light_module_color", "dark_module_color", "auto_module_px_size", "quiet_zone_size"]
 
 func _property_get_revert(property: StringName) -> Variant:
     match property:
@@ -274,6 +285,8 @@ func _property_get_revert(property: StringName) -> Variant:
             return Color.BLACK
         "auto_module_px_size":
             return true
+        "quiet_zone_size":
+            return 4
         _:
             return null
 
@@ -291,4 +304,4 @@ func _notification(what: int) -> void:
 func _update_qr() -> void:
     if self.auto_module_px_size:
         self.module_px_size = mini(self.size.x, self.size.y) / self._qr.get_module_count()
-    self.texture = ImageTexture.create_from_image(self._qr.generate_image(self.module_px_size, self.light_module_color, self.dark_module_color))
+    self.texture = ImageTexture.create_from_image(self._qr.generate_image(self.module_px_size, self.light_module_color, self.dark_module_color, self.quiet_zone_size))

--- a/addons/qr_code/qr_code_rect.gd
+++ b/addons/qr_code/qr_code_rect.gd
@@ -226,6 +226,8 @@ func _get_property_list() -> Array[Dictionary]:
         "hint": PROPERTY_HINT_RANGE,
         "hint_string": "1,1,or_greater"
     }
+    if self.auto_module_px_size:
+        module_px_size_prop["usage"] = (module_px_size_prop["usage"] | PROPERTY_USAGE_READ_ONLY) & ~PROPERTY_USAGE_STORAGE
 
     return [
         data_prop,

--- a/addons/qr_code/qr_code_rect.gd
+++ b/addons/qr_code/qr_code_rect.gd
@@ -48,7 +48,7 @@ var auto_module_px_size: bool = true:
 ## Use that many pixel for one module.
 var module_px_size: int = 1:
     set = set_module_px_size
-## Use that many modules for the quite zone. A value of 4 is recommend.
+## Use that many modules for the quiet zone. A value of 4 is recommended.
 var quiet_zone_size: int = 4:
     set = set_quiet_zone_size
 
@@ -305,5 +305,5 @@ func _notification(what: int) -> void:
 
 func _update_qr() -> void:
     if self.auto_module_px_size:
-        self.module_px_size = mini(self.size.x, self.size.y) / self._qr.get_module_count()
+        self.module_px_size = mini(self.size.x, self.size.y) / (self._qr.get_module_count() + 2 * self.quiet_zone_size)
     self.texture = ImageTexture.create_from_image(self._qr.generate_image(self.module_px_size, self.light_module_color, self.dark_module_color, self.quiet_zone_size))

--- a/examples/qr_code/main.gd
+++ b/examples/qr_code/main.gd
@@ -14,6 +14,7 @@ const QRCode = preload("res://addons/qr_code/qr_code.gd")
 @export var _dark_module_color: ColorPickerButton
 @export var _auto_module_px_size: CheckBox
 @export var _module_px_size: SpinBox
+@export var _quiet_zone_size: SpinBox
 
 @export var _qr_rect: QRCodeRect
 
@@ -80,4 +81,8 @@ func _on_auto_module_px_size_toggled(button_pressed: bool) -> void:
 
 func _on_module_px_size_value_changed(value: float) -> void:
 	self._qr_rect.module_px_size = int(value)
+	self._update_values()
+
+func _on_quiet_zone_size_value_changed(value: float):
+	self._qr_rect.quiet_zone_size = int(value)
 	self._update_values()

--- a/examples/qr_code/main.tscn
+++ b/examples/qr_code/main.tscn
@@ -190,6 +190,20 @@ allow_greater = true
 alignment = 1
 editable = false
 
+[node name="QuietZoneSizeLabel" type="Label" parent="MarginContainer2/VBoxContainer/options"]
+layout_mode = 2
+text = "Quiet Zone Size"
+
+[node name="Control6" type="Control" parent="MarginContainer2/VBoxContainer/options"]
+layout_mode = 2
+
+[node name="QuietZoneSize" type="SpinBox" parent="MarginContainer2/VBoxContainer/options"]
+layout_mode = 2
+size_flags_horizontal = 3
+value = 4.0
+allow_greater = true
+alignment = 1
+
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
 size_flags_horizontal = 3
@@ -213,6 +227,7 @@ auto_mask_pattern = true
 light_module_color = Color(1, 1, 1, 1)
 dark_module_color = Color(0, 0, 0, 1)
 auto_module_px_size = true
+quiet_zone_size = 4
 
 [node name="ColorRect" type="ColorRect" parent="."]
 layout_mode = 2
@@ -229,3 +244,4 @@ layout_mode = 2
 [connection signal="color_changed" from="MarginContainer2/VBoxContainer/options/DarkModuleColor" to="." method="_on_dark_module_color_color_changed"]
 [connection signal="toggled" from="MarginContainer2/VBoxContainer/options/AutoModulePxSize" to="." method="_on_auto_module_px_size_toggled"]
 [connection signal="value_changed" from="MarginContainer2/VBoxContainer/options/ModulePxSize" to="." method="_on_module_px_size_value_changed"]
+[connection signal="value_changed" from="MarginContainer2/VBoxContainer/options/QuietZoneSize" to="." method="_on_quiet_zone_size_value_changed"]


### PR DESCRIPTION
Amazing work on this extension! I've been trying to find a qr code plugin that actually works for a while now. Before this I tried using a modified version of [this addon](https://github.com/Greaby/godot-qrcode-generator/tree/godot-4) for the a little bit but it was super buggy.

This PR adds padding support for the qr code texture. The padding is based on `module_px_size`. The color uses the `light_module_color`.

Here's what a padding size of 1 looks like:
![image](https://github.com/kenyoni-software/godot-addons/assets/58660466/4bcee223-b65e-421e-9c84-1e4ced7d41fc)

I can't figure out how to get the inspector to only allow positive numbers and zero. I tried `editor_hint: '0,1,or_greater'` but it doesn't seam to work.