### PR TITLE
[Fix] Fix property not found warning in 'Hide Private Properties' plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ This plugin will hide exported private properties in the inspector for instantia
 
 ### Changelog
 
+#### 1.1.2
+
+- Fix: property not found warning
+
 #### 1.1.1
 
 - Use absolute paths in preloads

--- a/addons/hide_private_properties/inspector_plugin.gd
+++ b/addons/hide_private_properties/inspector_plugin.gd
@@ -1,6 +1,8 @@
 extends EditorInspectorPlugin
 
 func _can_handle(object: Object) -> bool:
+    # Early return if property does not exist, prevents triggering a warning for
+    # some objects that overwrite the 'get' method.
     if not _has_property(object, "scene_file_path"):
         return false
     
@@ -13,6 +15,8 @@ func _parse_property(object: Object, type: Variant.Type, name: String, hint_type
     return false
 
 func _has_property(object: Object, propertyName: String) -> bool:
+    # Note: Checking if the property exists using the 'in' keyword also triggers 
+    # the warning in 'core/config/project_settings.cpp:_get' (v4.2.1)
     for property in object.get_property_list():
         if property.name == propertyName:
             return true

--- a/addons/hide_private_properties/inspector_plugin.gd
+++ b/addons/hide_private_properties/inspector_plugin.gd
@@ -1,10 +1,19 @@
 extends EditorInspectorPlugin
 
 func _can_handle(object: Object) -> bool:
+    if not _has_property(object, "scene_file_path"):
+        return false
+    
     var scene_path: Variant = object.get("scene_file_path")
     return scene_path != null && scene_path != "" && object != EditorInterface.get_edited_scene_root()
 
 func _parse_property(object: Object, type: Variant.Type, name: String, hint_type: PropertyHint, hint_string: String, usage_flags: int, wide: bool) -> bool:
     if name.begins_with("_"):
         return true
+    return false
+
+func _has_property(object: Object, propertyName: String) -> bool:
+    for property in object.get_property_list():
+        if property.name == propertyName:
+            return true
     return false

--- a/addons/hide_private_properties/plugin.cfg
+++ b/addons/hide_private_properties/plugin.cfg
@@ -3,7 +3,7 @@
 name="Hide Private Properties"
 description="Hide exported private properties in the inspector for instantiated child scenes."
 author="Iceflower S"
-version="1.1.1"
+version="1.1.2"
 script="plugin.gd"
 license="MIT"
 repository="https://github.com/kenyoni-software/godot-addons"


### PR DESCRIPTION
A fix for the warning printed when starting the project with this plugin enabled (see #11 ).

- Added an early return in case the object does not have the property 'scene_file_path' using a custom property check function that does not produce a warning.
- Updated version to 1.1.2 in README.md and plugin.cfg to document changes

I hope everything is up to your standards with this PR, if not feel free to correct me.

(Sorry for #12 but I had to setup commit verification first, first time doing this ..I hope it works now)